### PR TITLE
Load drone 3D model in front-facing orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ _Figure 2 — Live SLAM map produced by the drone as it flies, showing the volum
   alt="Interactive 3D model of the calibration drone used in this project"
   camera-controls
   auto-rotate
+  camera-orbit="0deg 75deg auto"
   shadow-intensity="1"
   style="width: 100%; height: 500px;">
   Interactive 3D model of the calibration drone — view at the GitHub Pages site to rotate and inspect.


### PR DESCRIPTION
## Summary
- The interactive 3D drone in the README was loading with its underside facing the viewer.
- Adds `camera-orbit=\"0deg 75deg auto\"` to the `<model-viewer>` so it opens in a 3/4 front view with the top deck visible.
- `camera-controls` and `auto-rotate` remain on, so users can still drag/zoom freely.

## Test plan
- [ ] View the rendered README on the GitHub Pages site and confirm the drone loads front/top-facing instead of underside-up.
- [ ] Confirm drag-to-rotate, scroll-to-zoom, and auto-rotate still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)