### PR TITLE
Add curve-point waypoints and recreate-path-from-recording

### DIFF
--- a/qt-drone-ui/CMakeLists.txt
+++ b/qt-drone-ui/CMakeLists.txt
@@ -62,6 +62,7 @@ set(HEADERS
     src/widgets/dronestatuswidget.h
     src/controllers/dronecontroller.h
     src/models/waypoint.h
+    src/models/trajectory.h
     src/models/flightpath.h
     src/models/recording.h
     src/network/voxlconnection.h
@@ -69,6 +70,7 @@ set(HEADERS
     src/utils/settings.h
     src/utils/flightlogger.h
     src/utils/volumemanager.h
+    src/utils/pathfitter.h
 )
 
 # Source files
@@ -83,6 +85,7 @@ set(SOURCES
     src/widgets/dronestatuswidget.cpp
     src/controllers/dronecontroller.cpp
     src/models/waypoint.cpp
+    src/models/trajectory.cpp
     src/models/flightpath.cpp
     src/models/recording.cpp
     src/network/voxlconnection.cpp
@@ -90,6 +93,7 @@ set(SOURCES
     src/utils/settings.cpp
     src/utils/flightlogger.cpp
     src/utils/volumemanager.cpp
+    src/utils/pathfitter.cpp
 )
 
 # UI files

--- a/qt-drone-ui/src/controllers/dronecontroller.cpp
+++ b/qt-drone-ui/src/controllers/dronecontroller.cpp
@@ -9,6 +9,9 @@
 #include <QVector3D>
 #include <QtMath>
 #include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QFileInfo>
 #include <algorithm>
 #include <limits>
 
@@ -1655,4 +1658,117 @@ void DroneController::finishMapperMission(const QString &message)
     m_mapperPlanMismatchWarnedForCurrentTarget = false;
     emit missionStatusChanged(message);
     emit messageReceived(message);
+}
+
+// ── Trajectory helpers ────────────────────────────────────────────────────────
+
+QString DroneController::writeTrajectoryFile(const Trajectory &traj)
+{
+    const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)
+                        + QStringLiteral("/trajectories");
+    if (!QDir().mkpath(dir)) {
+        const QString reason = QStringLiteral("Failed to create trajectories directory: %1").arg(dir);
+        qDebug() << "[DroneController]" << reason;
+        emit trajectoryUploadFailed(reason);
+        return QString();
+    }
+
+    const QString filename = QString("traj_%1.json")
+                                 .arg(QDateTime::currentDateTime().toString("yyyyMMdd_HHmmss"));
+    const QString localPath = dir + QStringLiteral("/") + filename;
+
+    QFile file(localPath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        const QString reason = QStringLiteral("Failed to write trajectory file: %1").arg(localPath);
+        qDebug() << "[DroneController]" << reason;
+        emit trajectoryUploadFailed(reason);
+        return QString();
+    }
+    file.write(QJsonDocument(traj.toJson()).toJson(QJsonDocument::Indented));
+    file.close();
+
+    m_lastTrajectoryPath = localPath;
+    qDebug() << "[DroneController] Trajectory written to" << localPath;
+    return localPath;
+}
+
+void DroneController::uploadTrajectory(const Trajectory &traj)
+{
+    // Validate first.
+    const QStringList errors = traj.validate();
+    if (!errors.isEmpty()) {
+        qDebug() << "[DroneController] Trajectory validation failed:" << errors;
+        emit trajectoryValidationFailed(errors);
+        return;
+    }
+
+    // Write persistent JSON file.
+    const QString localPath = writeTrajectoryFile(traj);
+    if (localPath.isEmpty())
+        return; // writeTrajectoryFile already emitted trajectoryUploadFailed
+
+    m_trajectoryActive = false;
+    m_startingTrajectory = false;
+
+    const QString summary = QStringLiteral("%1 samples · %2 s · %3 m · peak %4 m/s")
+                                .arg(traj.samples().size())
+                                .arg(traj.duration(), 0, 'f', 1)
+                                .arg(traj.distance(), 0, 'f', 1)
+                                .arg(traj.peakSpeedMs(), 0, 'f', 1);
+
+    if (m_voxlConnection && m_connected) {
+        qDebug() << "[DroneController] Uploading trajectory to VOXL:" << localPath;
+        m_uploadingTrajectory = true;
+        m_voxlConnection->uploadFileToVoxl(localPath,
+                                           QStringLiteral("/data/trajectories/inbox/trajectory.json"),
+                                           QStringLiteral("trajectory"));
+        emit messageReceived(QStringLiteral("Uploading trajectory to VOXL: %1").arg(summary));
+    } else {
+        // Offline — stage locally only.
+        qDebug() << "[DroneController] Offline: trajectory staged locally" << localPath;
+        emit trajectoryStaged(localPath, summary);
+        emit messageReceived(QStringLiteral("Trajectory staged locally (offline): %1").arg(summary));
+    }
+}
+
+void DroneController::stageTrajectoryLocally(const Trajectory &traj)
+{
+    // Validate first.
+    const QStringList errors = traj.validate();
+    if (!errors.isEmpty()) {
+        qDebug() << "[DroneController] Trajectory validation failed (stage):" << errors;
+        emit trajectoryValidationFailed(errors);
+        return;
+    }
+
+    const QString localPath = writeTrajectoryFile(traj);
+    if (localPath.isEmpty())
+        return;
+
+    m_trajectoryActive = false;
+    m_startingTrajectory = false;
+
+    const QString summary = QStringLiteral("%1 samples · %2 s · %3 m · peak %4 m/s")
+                                .arg(traj.samples().size())
+                                .arg(traj.duration(), 0, 'f', 1)
+                                .arg(traj.distance(), 0, 'f', 1)
+                                .arg(traj.peakSpeedMs(), 0, 'f', 1);
+
+    qDebug() << "[DroneController] Trajectory staged locally:" << localPath;
+    emit trajectoryStaged(localPath, summary);
+    emit messageReceived(QStringLiteral("Trajectory staged locally: %1").arg(summary));
+}
+
+void DroneController::cancelTrajectory()
+{
+    if (!m_trajectoryActive && !m_uploadingTrajectory && !m_startingTrajectory)
+        return;
+
+    m_uploadingTrajectory = false;
+    m_startingTrajectory = false;
+    m_trajectoryActive = false;
+
+    emit trajectoryCancelled();
+    emit missionStatusChanged(QStringLiteral("Trajectory cancelled"));
+    emit messageReceived(QStringLiteral("Trajectory cancelled by user"));
 }

--- a/qt-drone-ui/src/controllers/dronecontroller.h
+++ b/qt-drone-ui/src/controllers/dronecontroller.h
@@ -7,9 +7,11 @@
 #include <QVector3D>
 #include <QColor>
 #include <QJsonObject>
+#include <QStringList>
 #include <vector>
 #include "../widgets/dronestatuswidget.h"
 #include "../models/waypoint.h"
+#include "../models/trajectory.h"
 #include "../network/voxlmapperclient.h"
 
 class VOXLConnection;
@@ -107,6 +109,18 @@ public:
     bool isMissionRunning() const { return m_missionActive; }
     bool isMissionPaused() const { return m_missionPaused; }
 
+    // Trajectory mode (parallels mapper mission API).
+    // Validates first; if invalid, emits trajectoryValidationFailed and returns.
+    // Online: writes JSON to persistent AppLocalData/trajectories/traj_<ts>.json,
+    //         then uploads via SCP to /data/trajectories/inbox/trajectory.json on VOXL.
+    //         After upload succeeds, execution is explicitly started via VOXL runner API.
+    // Offline: writes the same file and emits trajectoryStaged(path, summary) without uploading.
+    void uploadTrajectory(const Trajectory &traj);
+    void stageTrajectoryLocally(const Trajectory &traj);
+    void cancelTrajectory();
+    bool isTrajectoryActive() const { return m_trajectoryActive; }
+    QString lastTrajectoryFilePath() const { return m_lastTrajectoryPath; }
+
 signals:
     void connectionStatusChanged(bool connected);
     void statusUpdated(const DroneStatus &status);
@@ -118,6 +132,15 @@ signals:
     void warningIssued(const QString &warning);
     void messageReceived(const QString &message);
     void mapperBundleDownloadFinished(bool success, const QString &message);
+
+    // Trajectory signals
+    void trajectoryStaged(const QString &localPath, const QString &summary);   // summary: "N samples · X.X s · Y.Y m · peak Z.Z m/s"
+    void trajectoryUploaded(const QString &localPath);
+    void trajectoryStarted(const QString &missionFileName);
+    void trajectoryUploadFailed(const QString &reason);
+    void trajectoryStartFailed(const QString &reason);
+    void trajectoryValidationFailed(const QStringList &reasons);
+    void trajectoryCancelled();
 
 private slots:
     void onHeartbeatTimer();
@@ -137,6 +160,9 @@ private slots:
 private:
     void initializeConnection();
     void stopMapperPortalWatchdog();
+    // Writes traj JSON to AppLocalData/trajectories/, sets m_lastTrajectoryPath.
+    // Returns empty string on failure (also emits trajectoryUploadFailed).
+    QString writeTrajectoryFile(const Trajectory &traj);
     void requestStatus();
     void processStatusData(const QJsonObject &data);
     void processMissionStatus(const QJsonObject &data);
@@ -217,6 +243,12 @@ private:
     QTimer *m_mapperPortalWatchdog;
     QTimer *m_thermalPollTimer;
     
+    // Trajectory state
+    bool m_trajectoryActive = false;
+    QString m_lastTrajectoryPath;
+    bool m_uploadingTrajectory = false;   // tag to distinguish missionUploadComplete callers
+    bool m_startingTrajectory = false;
+
     // Manual control state
     bool m_manualControlActive;
     QTimer *m_manualControlTimer;

--- a/qt-drone-ui/src/models/trajectory.cpp
+++ b/qt-drone-ui/src/models/trajectory.cpp
@@ -1,0 +1,308 @@
+#include "trajectory.h"
+#include <QJsonArray>
+#include <QtMath>
+#include <cmath>
+#include <algorithm>
+
+// ---------------------------------------------------------------------------
+// TrajectorySample
+// ---------------------------------------------------------------------------
+
+QJsonObject TrajectorySample::toJson() const
+{
+    QJsonObject obj;
+    obj["t"] = t;
+    obj["p"] = QJsonArray{ positionNed.x(), positionNed.y(), positionNed.z() };
+    obj["v"] = QJsonArray{ velocityNed.x(), velocityNed.y(), velocityNed.z() };
+    obj["yaw"] = static_cast<double>(yawRad);
+    return obj;
+}
+
+// ---------------------------------------------------------------------------
+// Trajectory
+// ---------------------------------------------------------------------------
+
+Trajectory::Trajectory() = default;
+
+// Centripetal Catmull-Rom evaluation (Barry-Goldman form, alpha = 0.5).
+// Returns position on the segment between P1 and P2 at parameter tc in [t1, t2].
+static QVector3D catmullRomEval(const QVector3D& P0, const QVector3D& P1,
+                                const QVector3D& P2, const QVector3D& P3,
+                                float t0, float t1, float t2, float t3, float tc)
+{
+    const float d10 = std::max(t1 - t0, 1e-6f);
+    const float d21 = std::max(t2 - t1, 1e-6f);
+    const float d32 = std::max(t3 - t2, 1e-6f);
+    const float d20 = std::max(t2 - t0, 1e-6f);
+    const float d31 = std::max(t3 - t1, 1e-6f);
+
+    QVector3D A1 = ((t1 - tc) / d10) * P0 + ((tc - t0) / d10) * P1;
+    QVector3D A2 = ((t2 - tc) / d21) * P1 + ((tc - t1) / d21) * P2;
+    QVector3D A3 = ((t3 - tc) / d32) * P2 + ((tc - t2) / d32) * P3;
+    QVector3D B1 = ((t2 - tc) / d20) * A1 + ((tc - t0) / d20) * A2;
+    QVector3D B2 = ((t3 - tc) / d31) * A2 + ((tc - t1) / d31) * A3;
+    return ((t2 - tc) / d21) * B1 + ((tc - t1) / d21) * B2;
+}
+
+Trajectory Trajectory::fromWaypoints(const std::vector<Waypoint>& waypointsLogical,
+                                     float cruiseSpeedMs,
+                                     float sampleHz,
+                                     const QString& name)
+{
+    Trajectory traj;
+    traj.m_name = name;
+    traj.m_cruiseSpeedMs = cruiseSpeedMs;
+    traj.m_sampleHz = sampleHz;
+
+    if (cruiseSpeedMs <= 0.0f || sampleHz <= 0.0f)
+        return traj;
+
+    // Skip mapper-home entries.
+    std::vector<Waypoint> wps;
+    wps.reserve(waypointsLogical.size());
+    for (const Waypoint& wp : waypointsLogical) {
+        if (!wp.isMapperHome())
+            wps.push_back(wp);
+    }
+    if (wps.size() < 2)
+        return traj;
+
+    // Convert to NED positions: (logical.x, -logical.y, -logical.z).
+    const int M = static_cast<int>(wps.size());
+    QVector<QVector3D> P(M);
+    for (int i = 0; i < M; ++i) {
+        const QVector3D& p = wps[i].position();
+        P[i] = QVector3D(p.x(), -p.y(), -p.z());
+    }
+
+    const float dt = 1.0f / sampleHz;
+    const float ds = cruiseSpeedMs * dt; // step in meters between samples
+    if (ds <= 1e-6f)
+        return traj;
+
+    struct Raw {
+        QVector3D posNed;
+        int   srcLeg;        // index of leg-start waypoint (for yaw lookup)
+        bool  curveSample;   // true => yaw must be auto (atan2 of velocity)
+    };
+    QVector<Raw> raw;
+    raw.reserve(256);
+
+    // For each leg in (P[seg], P[seg+1]) emit samples [0..nSteps); endpoint emitted once at the end.
+    for (int seg = 0; seg < M - 1; ++seg) {
+        const QVector3D& A = P[seg];
+        const QVector3D& B = P[seg + 1];
+        const bool bothCurve = wps[seg].isCurve() && wps[seg + 1].isCurve();
+
+        // -- Curve leg: centripetal Catmull-Rom (alpha = 0.5) --
+        if (bothCurve) {
+            const QVector3D P0 = (seg == 0)     ? (2.0f * A - B) : P[seg - 1];
+            const QVector3D P3 = (seg == M - 2) ? (2.0f * B - A) : P[seg + 2];
+            const float t0 = 0.0f;
+            const float t1 = t0 + std::sqrt((A - P0).length());
+            const float t2 = t1 + std::sqrt((B - A).length());
+            const float t3 = t2 + std::sqrt((P3 - B).length());
+
+            if ((t2 - t1) < 1e-6f || (t1 - t0) < 1e-6f || (t3 - t2) < 1e-6f) {
+                // Degenerate → fall through to linear handling below.
+            } else {
+                // Estimate arc length with a 16-step Riemann sum.
+                const int kEst = 16;
+                float arcLen = 0.0f;
+                QVector3D prev = A;
+                for (int k = 1; k <= kEst; ++k) {
+                    const float u = float(k) / float(kEst);
+                    const float tc = t1 + u * (t2 - t1);
+                    const QVector3D cur = catmullRomEval(P0, A, B, P3, t0, t1, t2, t3, tc);
+                    arcLen += (cur - prev).length();
+                    prev = cur;
+                }
+                if (arcLen < 1e-6f) {
+                    raw.append({ A, seg, true });
+                    continue;
+                }
+                const int nSteps = std::max(2, int(std::ceil(arcLen / ds)));
+                for (int k = 0; k < nSteps; ++k) {
+                    const float u  = float(k) / float(nSteps);
+                    const float tc = t1 + u * (t2 - t1);
+                    raw.append({ catmullRomEval(P0, A, B, P3, t0, t1, t2, t3, tc), seg, true });
+                }
+                continue;
+            }
+        }
+
+        // -- Linear leg (also used when curve degenerates) --
+        const float legLen = (B - A).length();
+        if (legLen < 1e-6f) {
+            raw.append({ A, seg, false });
+            continue;
+        }
+        const int nSteps = std::max(1, int(std::ceil(legLen / ds)));
+        for (int k = 0; k < nSteps; ++k) {
+            const float u = float(k) / float(nSteps);
+            raw.append({ A + u * (B - A), seg, false });
+        }
+    }
+    // Final endpoint — last waypoint, exact.
+    raw.append({ P[M - 1], M - 2, wps[M - 1].isCurve() && wps[M - 2].isCurve() });
+
+    if (raw.size() < 2)
+        return traj;
+
+    const int N = raw.size();
+    traj.m_samples.resize(N);
+
+    // Time stamps
+    for (int i = 0; i < N; ++i) {
+        traj.m_samples[i].positionNed = raw[i].posNed;
+        traj.m_samples[i].t = double(i) * dt;
+    }
+
+    // Velocities (forward difference; final = 0)
+    for (int i = 0; i < N - 1; ++i) {
+        traj.m_samples[i].velocityNed =
+            (traj.m_samples[i + 1].positionNed - traj.m_samples[i].positionNed) * sampleHz;
+    }
+    traj.m_samples[N - 1].velocityNed = QVector3D(0.0f, 0.0f, 0.0f);
+
+    // Yaw: curve samples are ALWAYS auto (atan2 of velocity); waypoint-leg samples
+    // honor wps[srcLeg].yawAngle() if non-zero, else auto. Final sample copies previous.
+    for (int i = 0; i < N - 1; ++i) {
+        const Raw& r = raw[i];
+        if (r.curveSample) {
+            const QVector3D& v = traj.m_samples[i].velocityNed;
+            traj.m_samples[i].yawRad = std::atan2(v.y(), v.x());
+        } else {
+            const float wpYawDeg = wps[r.srcLeg].yawAngle();
+            if (std::abs(wpYawDeg) > 1e-6f) {
+                traj.m_samples[i].yawRad = qDegreesToRadians(wpYawDeg);
+            } else {
+                const QVector3D& v = traj.m_samples[i].velocityNed;
+                traj.m_samples[i].yawRad = std::atan2(v.y(), v.x());
+            }
+        }
+    }
+    traj.m_samples[N - 1].yawRad = (N >= 2) ? traj.m_samples[N - 2].yawRad : 0.0f;
+
+    return traj;
+}
+
+// ---------------------------------------------------------------------------
+// Preview helpers
+// ---------------------------------------------------------------------------
+
+QVector<QVector3D> Trajectory::previewSampledPositionsNed(
+    const std::vector<Waypoint>& waypointsLogical,
+    float cruiseSpeedMs,
+    float sampleHz)
+{
+    Trajectory traj = fromWaypoints(waypointsLogical, cruiseSpeedMs, sampleHz);
+    QVector<QVector3D> result;
+    result.reserve(traj.m_samples.size());
+    for (const TrajectorySample& s : traj.m_samples)
+        result.append(s.positionNed);
+    return result;
+}
+
+QVector<QVector3D> Trajectory::previewSampledPositionsLogical(
+    const std::vector<Waypoint>& waypointsLogical,
+    float cruiseSpeedMs,
+    float sampleHz)
+{
+    // Build NED positions, then invert the NED flip: logical = (n, -e, -d)
+    QVector<QVector3D> ned = previewSampledPositionsNed(waypointsLogical, cruiseSpeedMs, sampleHz);
+    QVector<QVector3D> result;
+    result.reserve(ned.size());
+    for (const QVector3D& p : ned)
+        result.append(QVector3D(p.x(), -p.y(), -p.z()));
+    return result;
+}
+
+QStringList Trajectory::validate() const
+{
+    QStringList errors;
+
+    if (m_samples.isEmpty()) {
+        errors << QStringLiteral("Trajectory has no samples.");
+        return errors;
+    }
+
+    // Check monotonically increasing t
+    for (int i = 1; i < m_samples.size(); ++i) {
+        if (m_samples[i].t <= m_samples[i - 1].t) {
+            errors << QStringLiteral("Time is not monotonically increasing at sample %1.").arg(i);
+        }
+    }
+
+    // Per-sample spatial and speed checks
+    for (int i = 0; i < m_samples.size(); ++i) {
+        const TrajectorySample& s = m_samples[i];
+        float north = s.positionNed.x();
+        float east  = s.positionNed.y();
+        float down  = s.positionNed.z();
+
+        if (std::abs(north) > 50.0f)
+            errors << QStringLiteral("Sample %1: |north| = %2 m exceeds 50 m limit.").arg(i).arg(north, 0, 'f', 2);
+        if (std::abs(east) > 50.0f)
+            errors << QStringLiteral("Sample %1: |east| = %2 m exceeds 50 m limit.").arg(i).arg(east, 0, 'f', 2);
+        // down in NED is negative altitude above ground; valid range: down in [-30, 0] means alt 0..30 m AGL
+        if (down < -30.0f || down > 0.0f)
+            errors << QStringLiteral("Sample %1: down = %2 m is outside [-30, 0] range.").arg(i).arg(down, 0, 'f', 2);
+
+        float speed = s.velocityNed.length();
+        if (speed > 5.0f)
+            errors << QStringLiteral("Sample %1: speed = %2 m/s exceeds 5 m/s limit.").arg(i).arg(speed, 0, 'f', 2);
+    }
+
+    // Final velocity must be near zero
+    const TrajectorySample& last = m_samples.last();
+    if (last.velocityNed.length() >= 1e-3f) {
+        errors << QStringLiteral("Final sample velocity |v| = %1 m/s is not zero.")
+                      .arg(last.velocityNed.length(), 0, 'f', 4);
+    }
+
+    return errors;
+}
+
+QJsonObject Trajectory::toJson() const
+{
+    QJsonObject obj;
+    obj["name"] = m_name;
+    obj["hz"] = static_cast<double>(m_sampleHz);
+    obj["cruise_ms"] = static_cast<double>(m_cruiseSpeedMs);
+
+    QJsonArray samplesArray;
+    for (const TrajectorySample& s : m_samples) {
+        samplesArray.append(s.toJson());
+    }
+    obj["samples"] = samplesArray;
+
+    return obj;
+}
+
+float Trajectory::duration() const
+{
+    if (m_samples.size() < 2)
+        return 0.0f;
+    return static_cast<float>(m_samples.last().t - m_samples.first().t);
+}
+
+float Trajectory::distance() const
+{
+    float total = 0.0f;
+    for (int i = 1; i < m_samples.size(); ++i) {
+        total += (m_samples[i].positionNed - m_samples[i - 1].positionNed).length();
+    }
+    return total;
+}
+
+float Trajectory::peakSpeedMs() const
+{
+    float peak = 0.0f;
+    for (const TrajectorySample& s : m_samples) {
+        float speed = s.velocityNed.length();
+        if (speed > peak)
+            peak = speed;
+    }
+    return peak;
+}

--- a/qt-drone-ui/src/models/trajectory.h
+++ b/qt-drone-ui/src/models/trajectory.h
@@ -1,0 +1,76 @@
+#ifndef TRAJECTORY_H
+#define TRAJECTORY_H
+
+#include "waypoint.h"
+#include <QVector>
+#include <QVector3D>
+#include <QJsonObject>
+#include <QString>
+#include <QStringList>
+#include <vector>
+
+struct TrajectorySample {
+    double t;               // seconds from start
+    QVector3D positionNed;  // North, East, Down (meters)
+    QVector3D velocityNed;  // m/s
+    float yawRad;
+
+    QJsonObject toJson() const;
+};
+
+class Trajectory
+{
+public:
+    Trajectory();
+
+    // Densify a list of logical-frame waypoints (Z-up) into time-sampled NED samples.
+    // cruiseSpeedMs > 0, sampleHz > 0. Final sample velocity is forced to zero.
+    // Yaw: if the source waypoint has a non-zero yawAngle(), use it (converted to rad);
+    // otherwise yaw follows the velocity heading. For the final (zero-vel) sample, hold the previous yaw.
+    // Coordinate flip: NED = (logical.x, -logical.y, -logical.z)
+    static Trajectory fromWaypoints(const std::vector<Waypoint>& waypointsLogical,
+                                    float cruiseSpeedMs,
+                                    float sampleHz,
+                                    const QString& name = QString());
+
+    // Returns empty list if valid; otherwise human-readable rule violations.
+    // Rules: |north|<=50, |east|<=50, -30<=down<=0, |v|<=5 m/s,
+    // monotonically increasing t, final |v| < 1e-3.
+    QStringList validate() const;
+
+    // { name, hz, cruise_ms, samples: [{t, p:[n,e,d], v:[n,e,d], yaw}, ...] }
+    QJsonObject toJson() const;
+
+    float duration() const;     // seconds
+    float distance() const;     // total path length (sum of |Δp|), meters
+    float peakSpeedMs() const;  // max |v|
+
+    QString name() const { return m_name; }
+    void setName(const QString& n) { m_name = n; }
+    float cruiseSpeedMs() const { return m_cruiseSpeedMs; }
+    float sampleHz() const { return m_sampleHz; }
+    const QVector<TrajectorySample>& samples() const { return m_samples; }
+    bool isEmpty() const { return m_samples.isEmpty(); }
+
+    // Position-only preview for visualization. Returns the sampled NED positions
+    // from a Trajectory built with fromWaypoints, without exposing the full sample set.
+    static QVector<QVector3D> previewSampledPositionsNed(
+        const std::vector<Waypoint>& waypointsLogical,
+        float cruiseSpeedMs,
+        float sampleHz);
+
+    // Same as previewSampledPositionsNed but in the logical (Z-up) frame used by the
+    // renderer. Each NED position (n, e, d) is mapped back to (n, -e, -d).
+    static QVector<QVector3D> previewSampledPositionsLogical(
+        const std::vector<Waypoint>& waypointsLogical,
+        float cruiseSpeedMs,
+        float sampleHz);
+
+private:
+    QString m_name;
+    float m_cruiseSpeedMs = 0.0f;
+    float m_sampleHz = 0.0f;
+    QVector<TrajectorySample> m_samples;
+};
+
+#endif // TRAJECTORY_H

--- a/qt-drone-ui/src/models/waypoint.cpp
+++ b/qt-drone-ui/src/models/waypoint.cpp
@@ -80,6 +80,7 @@ QJsonObject Waypoint::toJson() const
     json["sequence"] = m_sequence;
     json["type"] = m_waypointType;
     json["acceptance_radius"] = static_cast<double>(m_acceptanceRadius);
+    json["corner_radius"] = static_cast<double>(m_cornerRadiusM);
     json["pass_through"] = m_passThrough;
     
     // Local position for UI
@@ -109,6 +110,7 @@ Waypoint Waypoint::fromJson(const QJsonObject &json)
     wp.m_sequence = json["sequence"].toInt(0);
     wp.m_waypointType = json["type"].toString("NAV_WAYPOINT");
     wp.m_acceptanceRadius = static_cast<float>(json["acceptance_radius"].toDouble(0.5));
+    wp.m_cornerRadiusM = static_cast<float>(json["corner_radius"].toDouble(0.0));
     wp.m_passThrough = json["pass_through"].toBool(false);
     
     // Local position
@@ -132,6 +134,33 @@ bool Waypoint::isMapperHome() const
 void Waypoint::setAsMapperHome(bool enable)
 {
     m_waypointType = enable ? QStringLiteral("MAPPER_HOME") : QStringLiteral("NAV_WAYPOINT");
+}
+
+void Waypoint::setCurve(bool enable)
+{
+    if (isMapperHome())
+        return;
+
+    if (enable) {
+        m_waypointType = QStringLiteral("CURVE");
+        m_yawAngle = 0.0f; // curve points have auto yaw
+    } else {
+        if (m_waypointType == QStringLiteral("CURVE"))
+            m_waypointType = QStringLiteral("NAV_WAYPOINT");
+    }
+}
+
+void Waypoint::setYawAngle(float angle)
+{
+    if (isCurve()) return; // curve points have auto yaw — ignore user setting
+    m_yawAngle = angle;
+}
+
+void Waypoint::setCornerRadius(float r)
+{
+    m_cornerRadiusM = qBound(0.0f, r, 10.0f);
+    // NOTE: radius is deliberately decoupled from waypoint type.
+    // Use setCurve() to toggle CURVE mode independently.
 }
 
 QString Waypoint::toString() const
@@ -162,7 +191,8 @@ bool Waypoint::operator==(const Waypoint &other) const
            std::abs(m_relativeAltitudeM - other.m_relativeAltitudeM) < kFloatEps &&
            std::abs(m_acceptanceRadius - other.m_acceptanceRadius) < kFloatEps &&
            std::abs(m_holdTime - other.m_holdTime) < kFloatEps &&
-           std::abs(m_yawAngle - other.m_yawAngle) < kFloatEps;
+           std::abs(m_yawAngle - other.m_yawAngle) < kFloatEps &&
+           std::abs(m_cornerRadiusM - other.m_cornerRadiusM) < kFloatEps;
 }
 
 bool Waypoint::operator!=(const Waypoint &other) const

--- a/qt-drone-ui/src/models/waypoint.h
+++ b/qt-drone-ui/src/models/waypoint.h
@@ -37,7 +37,15 @@ public:
     /// VOXL mapper / planner home marker (serialized as type "MAPPER_HOME"); sequence id 0 in the mission UI.
     bool isMapperHome() const;
     void setAsMapperHome(bool enable = true);
-    
+
+    /// Curve waypoint — the drone arcs tangent through this point.
+    bool isCurve() const { return m_waypointType == "CURVE"; }
+    void setCurve(bool enable);
+
+    /// Turn-radius for this vertex in meters. 0 = sharp visit (no arc).
+    float cornerRadius() const { return m_cornerRadiusM; }
+    void setCornerRadius(float r);
+
     // Setters
     void setPosition(const QVector3D &position) { m_position = position; }
     void setPosition(float x, float y, float z) { m_position = QVector3D(x, y, z); }
@@ -61,7 +69,8 @@ public:
     void setWaypointType(const QString &type) { m_waypointType = type; }
     void setAcceptanceRadius(float radius) { m_acceptanceRadius = radius; }
     void setHoldTime(float time) { m_holdTime = time; }
-    void setYawAngle(float angle) { m_yawAngle = angle; }
+    /// No-op on curve waypoints (their yaw is auto-derived from velocity heading).
+    void setYawAngle(float angle);
     void setPassThrough(bool passThrough) { m_passThrough = passThrough; }
     
     // Utility functions
@@ -94,6 +103,7 @@ private:
     float m_yawAngle;
     bool m_passThrough;
     QDateTime m_createdAt;
+    float m_cornerRadiusM = 0.0f; ///< Turn radius at this vertex (m); 0 = sharp.
 };
 
 Q_DECLARE_METATYPE(Waypoint)

--- a/qt-drone-ui/src/utils/pathfitter.cpp
+++ b/qt-drone-ui/src/utils/pathfitter.cpp
@@ -1,0 +1,254 @@
+#include "pathfitter.h"
+
+#include <QString>
+#include <QtMath>
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+#include <vector>
+
+namespace {
+
+int trimLeadingStationary(const QVector<TimedSample> &raw, float eps, int run)
+{
+    if (raw.size() < 2)
+        return 0;
+    int consecutive = 0;
+    int i = 0;
+    for (; i + 1 < raw.size(); ++i) {
+        const float step = (raw[i + 1].positionLogical - raw[i].positionLogical).length();
+        if (step < eps) {
+            if (++consecutive < run)
+                continue;
+        } else {
+            // First non-stationary step found — keep the sample that begins moving.
+            return i;
+        }
+    }
+    return i;
+}
+
+int trimTrailingStationary(const QVector<TimedSample> &raw, int startIdx, float eps, int run)
+{
+    if (raw.size() - startIdx < 2)
+        return raw.size() - 1;
+    int consecutive = 0;
+    int i = raw.size() - 1;
+    for (; i > startIdx; --i) {
+        const float step = (raw[i].positionLogical - raw[i - 1].positionLogical).length();
+        if (step < eps) {
+            if (++consecutive < run)
+                continue;
+        } else {
+            return i;
+        }
+    }
+    return startIdx;
+}
+
+QVector<QVector3D> smoothMovingAverage(const QVector<QVector3D> &pts, int radius)
+{
+    if (radius <= 0 || pts.size() < 3)
+        return pts;
+    QVector<QVector3D> out;
+    out.resize(pts.size());
+    const int nPts = static_cast<int>(pts.size());
+    for (int i = 0; i < nPts; ++i) {
+        const int lo = std::max(0, i - radius);
+        const int hi = std::min(nPts - 1, i + radius);
+        // Accumulate in double to preserve precision for sub-meter / sub-cm traces.
+        double ax = 0.0, ay = 0.0, az = 0.0;
+        int n = 0;
+        for (int k = lo; k <= hi; ++k) {
+            ax += pts[k].x();
+            ay += pts[k].y();
+            az += pts[k].z();
+            ++n;
+        }
+        if (n > 0) {
+            const double inv = 1.0 / double(n);
+            out[i] = QVector3D(float(ax * inv), float(ay * inv), float(az * inv));
+        } else {
+            out[i] = pts[i];
+        }
+    }
+    return out;
+}
+
+// Perpendicular distance from point p to the infinite line through a-b.
+float perpendicularDistance3D(const QVector3D &p, const QVector3D &a, const QVector3D &b)
+{
+    const QVector3D ab = b - a;
+    const float abLen = ab.length();
+    if (abLen < 1e-6f)
+        return (p - a).length();
+    const QVector3D cross = QVector3D::crossProduct(p - a, ab);
+    return cross.length() / abLen;
+}
+
+// Iterative Ramer-Douglas-Peucker — returns sorted indices of surviving points.
+std::vector<int> rdpIndices(const QVector<QVector3D> &pts, float toleranceM)
+{
+    std::vector<int> keep;
+    if (pts.size() < 2)
+        return keep;
+    std::vector<bool> survives(pts.size(), false);
+    survives.front() = true;
+    survives.back() = true;
+
+    // Stack of [lo, hi] index ranges to examine.
+    std::vector<std::pair<int, int>> stack;
+    stack.emplace_back(0, pts.size() - 1);
+    while (!stack.empty()) {
+        const auto [lo, hi] = stack.back();
+        stack.pop_back();
+        if (hi - lo < 2)
+            continue;
+        float maxDist = -1.0f;
+        int maxIdx = -1;
+        for (int i = lo + 1; i < hi; ++i) {
+            const float d = perpendicularDistance3D(pts[i], pts[lo], pts[hi]);
+            if (d > maxDist) {
+                maxDist = d;
+                maxIdx = i;
+            }
+        }
+        if (maxIdx >= 0 && maxDist > toleranceM) {
+            survives[maxIdx] = true;
+            stack.emplace_back(lo, maxIdx);
+            stack.emplace_back(maxIdx, hi);
+        }
+    }
+
+    keep.reserve(pts.size());
+    for (int i = 0; i < pts.size(); ++i) {
+        if (survives[i])
+            keep.push_back(i);
+    }
+    return keep;
+}
+
+} // namespace
+
+PathFitResult fitPathFromSamples(const QVector<TimedSample> &raw, const PathFitOptions &opts)
+{
+    PathFitResult result;
+    result.rawSampleCount = raw.size();
+
+    if (raw.size() < 2)
+        return result;
+
+    // 1. Trim stationary head and tail.
+    const int startIdx = trimLeadingStationary(raw, opts.stationaryEpsM, opts.stationaryRun);
+    const int endIdx = trimTrailingStationary(raw, startIdx, opts.stationaryEpsM, opts.stationaryRun);
+    if (endIdx - startIdx < 1)
+        return result; // Entirely stationary.
+
+    const int n = endIdx - startIdx + 1;
+    result.trimmedSampleCount = n;
+
+    // 2. Backbone = cleaned (post-trim, pre-smooth) raw positions.
+    QVector<QVector3D> cleanedRaw;
+    cleanedRaw.reserve(n);
+    for (int i = startIdx; i <= endIdx; ++i)
+        cleanedRaw.append(raw[i].positionLogical);
+    result.backboneLogical = cleanedRaw;
+
+    // 2b. Auto-scale the RDP tolerance and corner-radius bounds to the trace extent so the
+    //     fitter behaves correctly on both 3 m loops and 30 cm hover-arounds. Doubles
+    //     across the reduction so sub-mm coordinates don't lose precision in the diagonal.
+    double minX = cleanedRaw.first().x(), maxX = minX;
+    double minY = cleanedRaw.first().y(), maxY = minY;
+    double minZ = cleanedRaw.first().z(), maxZ = minZ;
+    for (const QVector3D &p : cleanedRaw) {
+        minX = std::min(minX, double(p.x())); maxX = std::max(maxX, double(p.x()));
+        minY = std::min(minY, double(p.y())); maxY = std::max(maxY, double(p.y()));
+        minZ = std::min(minZ, double(p.z())); maxZ = std::max(maxZ, double(p.z()));
+    }
+    const double dx = maxX - minX, dy = maxY - minY, dz = maxZ - minZ;
+    const float D = float(std::sqrt(dx * dx + dy * dy + dz * dz));
+
+    // Tolerance: smaller of the user ceiling and 2% of D; floored at 3 mm.
+    const float effTolerance  = std::max(0.003f, std::min(opts.toleranceM, 0.02f * D));
+    // Corner radius range, expressed as a fraction of D, but never larger than the user ceilings.
+    const float effMinCornerR = std::min(opts.minCornerRadM, std::max(0.005f, 0.03f * D));
+    const float effMaxCornerR = std::min(opts.maxCornerRadM, std::max(0.05f,  0.40f * D));
+
+    // 3. Estimate sample rate and smooth.
+    float hz = 2.0f;
+    const double tSpan = raw[endIdx].t - raw[startIdx].t;
+    if (tSpan > 1e-3 && n > 1)
+        hz = static_cast<float>((n - 1) / tSpan);
+    const int smoothRadius = std::max(1, static_cast<int>(std::ceil(0.5f * opts.smoothWindowSec * hz)));
+    const QVector<QVector3D> smoothed = smoothMovingAverage(cleanedRaw, smoothRadius);
+
+    // 4. RDP simplify in 3D with the scale-adaptive tolerance.
+    const std::vector<int> survivors = rdpIndices(smoothed, effTolerance);
+    if (survivors.size() < 2) {
+        // Degenerate: emit a single NAV waypoint at the cleaned midpoint.
+        Waypoint w(smoothed[smoothed.size() / 2]);
+        w.setWaypointType(QStringLiteral("NAV_WAYPOINT"));
+        w.setAcceptanceRadius(opts.defaultAcceptanceRadiusM);
+        w.setHoldTime(0.0f);
+        w.setPassThrough(false);
+        w.setSequence(0);
+        w.setName(QStringLiteral("rec_0"));
+        result.waypoints.push_back(std::move(w));
+        return result;
+    }
+
+    // 5. Build waypoints. Endpoints = NAV, interior = CURVE with derived corner radius.
+    result.waypoints.reserve(survivors.size());
+    for (size_t k = 0; k < survivors.size(); ++k) {
+        const int idx = survivors[k];
+        const int origIdx = startIdx + idx;
+        const bool isEndpoint = (k == 0) || (k + 1 == survivors.size());
+
+        Waypoint w(smoothed[idx]);
+        w.setSequence(static_cast<int>(k));
+        w.setName(QStringLiteral("rec_%1").arg(k));
+        w.setAcceptanceRadius(opts.defaultAcceptanceRadiusM);
+        w.setHoldTime(0.0f);
+        w.setPassThrough(false);
+        w.setYawAngle(raw[origIdx].yawDeg); // No-op on CURVE per waypoint.cpp; stored on NAV endpoints.
+
+        if (isEndpoint) {
+            w.setWaypointType(QStringLiteral("NAV_WAYPOINT"));
+        } else {
+            // Variable corner radius from the local turn geometry — gentle bends get small arcs
+            // that hug the original recording, sharp bends get the largest arc that still fits
+            // between V's neighbors. This is the "curve of best fit through all the points"
+            // behavior, with adaptive bounds derived from the trace extent.
+            const int prevIdx = survivors[k - 1];
+            const int nextIdx = survivors[k + 1];
+            const QVector3D V = smoothed[idx];
+            const QVector3D P = smoothed[prevIdx];
+            const QVector3D N = smoothed[nextIdx];
+            const QVector3D vp = (P - V);
+            const QVector3D vn = (N - V);
+            const float lenVP = vp.length();
+            const float lenVN = vn.length();
+
+            float r = effMinCornerR;
+            if (lenVP > 1e-6f && lenVN > 1e-6f) {
+                const QVector3D vpUnit = vp / lenVP;
+                const QVector3D vnUnit = vn / lenVN;
+                const float cosTheta = std::clamp(QVector3D::dotProduct(vpUnit, vnUnit), -1.0f, 1.0f);
+                const float theta = std::acos(cosTheta);              // interior angle at V
+                // Half of the *turn* angle = (pi - theta) / 2.
+                const float halfTurn = 0.5f * (float(M_PI) - theta);
+                // Avoid blow-up for near-collinear (theta -> pi, halfTurn -> 0) and near-U-turn cases.
+                const float halfTan = std::tan(std::clamp(halfTurn, 1e-3f, float(M_PI) * 0.5f - 1e-3f));
+                const float legCap = 0.5f * std::min(lenVP, lenVN);
+                const float rGeom = legCap * halfTan;
+                r = std::clamp(rGeom, effMinCornerR, effMaxCornerR);
+            }
+            w.setCurve(true);
+            w.setCornerRadius(r);
+        }
+        result.waypoints.push_back(std::move(w));
+    }
+
+    return result;
+}

--- a/qt-drone-ui/src/utils/pathfitter.h
+++ b/qt-drone-ui/src/utils/pathfitter.h
@@ -1,0 +1,37 @@
+#ifndef PATHFITTER_H
+#define PATHFITTER_H
+
+#include <QVector>
+#include <QVector3D>
+#include <vector>
+
+#include "../models/waypoint.h"
+
+struct TimedSample {
+    double t;                  // seconds from start of recording
+    QVector3D positionLogical; // X-forward, Y-left, Z-up
+    float yawDeg;
+};
+
+struct PathFitOptions {
+    float toleranceM      = 0.15f;  // RDP perpendicular tolerance (m); matches default acceptance_radius
+    float smoothWindowSec = 0.5f;   // centered moving-average window
+    float stationaryEpsM  = 0.05f;  // |Δp| threshold for trim
+    int   stationaryRun   = 4;      // consecutive sub-eps steps that count as "stationary"
+    float minCornerRadM   = 0.10f;
+    float maxCornerRadM   = 0.75f;
+    float defaultAcceptanceRadiusM = 0.15f;
+};
+
+struct PathFitResult {
+    std::vector<Waypoint> waypoints;            // first + last = NAV_WAYPOINT; interior = CURVE
+    QVector<QVector3D>    backboneLogical;      // post-trim raw trace for the overlay
+    int                   rawSampleCount = 0;
+    int                   trimmedSampleCount = 0;
+};
+
+/// Reverse-engineer a curve-point planner path from a recorded manual flight.
+PathFitResult fitPathFromSamples(const QVector<TimedSample> &raw,
+                                 const PathFitOptions &opts = PathFitOptions());
+
+#endif // PATHFITTER_H

--- a/qt-drone-ui/src/widgets/pathplannerwidget.cpp
+++ b/qt-drone-ui/src/widgets/pathplannerwidget.cpp
@@ -1,6 +1,8 @@
 #include "pathplannerwidget.h"
 #include "../controllers/dronecontroller.h"
 #include "../models/flightpath.h"
+#include "../utils/pathfitter.h"
+#include <QRegularExpression>
 #include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -434,9 +436,10 @@ static const char *fragmentShaderSource =
     "#version 330 core\n"
     "in vec3 FragColor;\n"
     "out vec4 color;\n"
+    "uniform float uAlpha;\n"
     "void main()\n"
     "{\n"
-    "   color = vec4(FragColor, 1.0);\n"
+    "   color = vec4(FragColor, uAlpha);\n"
     "}\n\0";
 
 // PathPlannerOpenGLWidget Implementation
@@ -453,6 +456,15 @@ PathPlannerOpenGLWidget::PathPlannerOpenGLWidget(QWidget *parent)
         m_animationTime += 0.016f;
         update(); });
     m_animationTimer->start();
+
+    // Re-shows the recording backbone shortly after the user finishes a wheel/zoom flick.
+    m_backboneRevealTimer = new QTimer(this);
+    m_backboneRevealTimer->setSingleShot(true);
+    m_backboneRevealTimer->setInterval(120);
+    connect(m_backboneRevealTimer, &QTimer::timeout, this, [this]() {
+        m_cameraInteracting = false;
+        update();
+    });
 }
 
 PathPlannerOpenGLWidget::~PathPlannerOpenGLWidget()
@@ -512,14 +524,19 @@ void PathPlannerOpenGLWidget::paintGL()
     m_shaderProgram->setUniformValue("projection", m_projectionMatrix);
     m_shaderProgram->setUniformValue("view", m_viewMatrix);
     m_shaderProgram->setUniformValue("model", m_modelMatrix);
+    m_shaderProgram->setUniformValue("uAlpha", 1.0f);
 
     drawGrid();
     drawAxes();
     drawMapperRenderData();
     drawDroneAxes();
     drawPath();
-    drawWaypoints();
-    drawGizmo();
+    drawRecordingBackbone();
+    if (!m_decorationsHidden)
+    {
+        drawWaypoints();
+        drawGizmo();
+    }
 
     m_shaderProgram->release();
 }
@@ -538,7 +555,8 @@ void PathPlannerOpenGLWidget::paintEvent(QPaintEvent *event)
     // Then draw 2D overlays using QPainter
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing);
-    drawWaypointLabels(painter);
+    if (!m_decorationsHidden)
+        drawWaypointLabels(painter);
     painter.end();
 }
 
@@ -1153,6 +1171,89 @@ void PathPlannerOpenGLWidget::drawMapperRenderData()
     m_vao.release();
 }
 
+void PathPlannerOpenGLWidget::setRecordingBackbone(const QVector<QVector3D> &positionsLogical)
+{
+    m_recordingBackbonePositionsLogical = positionsLogical;
+    update();
+}
+
+void PathPlannerOpenGLWidget::clearRecordingBackbone()
+{
+    m_recordingBackbonePositionsLogical.clear();
+    update();
+}
+
+void PathPlannerOpenGLWidget::drawRecordingBackbone()
+{
+    // Hidden during camera manipulation so the user can inspect the fitted curve in isolation.
+    if (m_cameraInteracting || m_recordingBackbonePositionsLogical.size() < 2)
+        return;
+
+    // Resample by arc length so the dash pattern is uniform regardless of raw cadence,
+    // then emit alternating segments to GL_LINES (poor man's stipple — no GL_LINE_STIPPLE in core).
+    const float dashLenM = 0.10f; // ~10 cm dashes
+    QVector<QVector3D> resampled;
+    resampled.reserve(m_recordingBackbonePositionsLogical.size() * 2);
+    resampled.append(m_recordingBackbonePositionsLogical.first());
+    float carry = 0.0f;
+    for (int i = 1; i < m_recordingBackbonePositionsLogical.size(); ++i) {
+        const QVector3D &a = m_recordingBackbonePositionsLogical[i - 1];
+        const QVector3D &b = m_recordingBackbonePositionsLogical[i];
+        const QVector3D d = b - a;
+        const float segLen = d.length();
+        if (segLen < 1e-6f)
+            continue;
+        const QVector3D dir = d / segLen;
+        float distAlong = dashLenM - carry;
+        while (distAlong < segLen) {
+            resampled.append(a + dir * distAlong);
+            distAlong += dashLenM;
+        }
+        carry = segLen - (distAlong - dashLenM);
+    }
+
+    QVector<float> vertices;
+    QVector<float> colors;
+    vertices.reserve(resampled.size() * 3);
+    colors.reserve(resampled.size() * 3);
+
+    // Light gray. Emit pairs [0,1], [2,3], [4,5], ... — every other segment skipped → dashed look.
+    for (int i = 0; i + 1 < resampled.size(); i += 2) {
+        const QVector3D p1 = logicalToWorld(resampled[i]);
+        const QVector3D p2 = logicalToWorld(resampled[i + 1]);
+        vertices << p1.x() << p1.y() << p1.z();
+        vertices << p2.x() << p2.y() << p2.z();
+        colors << 0.78f << 0.82f << 0.88f;
+        colors << 0.78f << 0.82f << 0.88f;
+    }
+
+    if (vertices.isEmpty())
+        return;
+
+    m_vao.bind();
+    m_vertexBuffer.bind();
+    m_vertexBuffer.allocate(vertices.data(), vertices.size() * sizeof(float));
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), nullptr);
+    glEnableVertexAttribArray(0);
+
+    QOpenGLBuffer colorBuffer;
+    colorBuffer.create();
+    colorBuffer.bind();
+    colorBuffer.allocate(colors.data(), colors.size() * sizeof(float));
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), nullptr);
+    glEnableVertexAttribArray(1);
+
+    m_shaderProgram->setUniformValue("uAlpha", 0.35f);
+    glLineWidth(2.0f);
+    glDrawArrays(GL_LINES, 0, vertices.size() / 3);
+    glLineWidth(1.0f);
+    m_shaderProgram->setUniformValue("uAlpha", 1.0f);
+
+    colorBuffer.release();
+    m_vertexBuffer.release();
+    m_vao.release();
+}
+
 // Helper function to generate sphere vertices for waypoint balls
 static void generateSphereVertices(const QVector3D &center, float radius,
                                     const QVector3D &color, QVector<float> &vertices, QVector<float> &colors)
@@ -1313,28 +1414,43 @@ void PathPlannerOpenGLWidget::drawWaypoints()
         const Waypoint &wp = m_waypoints[i];
         const QVector3D center = waypointToWorld(wp);
         const bool homeWp = wp.isMapperHome();
+        const bool curveWp = wp.isCurve();
         QVector3D color;
 
         if (wp.sequence() == m_selectedWaypoint)
         {
-            color = homeWp ? QVector3D(1.0f, 0.88f, 0.45f) : QVector3D(0.56f, 0.76f, 1.0f);
+            color = homeWp ? QVector3D(1.0f, 0.88f, 0.45f)
+                  : curveWp ? QVector3D(0.85f, 0.55f, 1.0f)
+                  : QVector3D(0.56f, 0.76f, 1.0f);
         }
         else if (m_selectedWaypointIds.contains(wp.sequence()))
         {
-            color = homeWp ? QVector3D(1.0f, 0.78f, 0.35f) : QVector3D(0.2f, 0.72f, 0.95f);
+            color = homeWp ? QVector3D(1.0f, 0.78f, 0.35f)
+                  : curveWp ? QVector3D(0.75f, 0.45f, 0.95f)
+                  : QVector3D(0.2f, 0.72f, 0.95f);
         }
         else if (wp.sequence() == m_hoveredWaypoint)
         {
-            color = homeWp ? QVector3D(1.0f, 0.72f, 0.28f) : QVector3D(0.38f, 0.65f, 1.0f);
+            color = homeWp ? QVector3D(1.0f, 0.72f, 0.28f)
+                  : curveWp ? QVector3D(0.70f, 0.40f, 0.90f)
+                  : QVector3D(0.38f, 0.65f, 1.0f);
         }
         else
         {
-            color = homeWp ? QVector3D(0.95f, 0.62f, 0.15f) : QVector3D(0.12f, 0.42f, 0.92f);
+            color = homeWp ? QVector3D(0.95f, 0.62f, 0.15f)
+                  : curveWp ? QVector3D(0.58f, 0.28f, 0.85f)
+                  : QVector3D(0.12f, 0.42f, 0.92f);
         }
 
-        float lenS = 1.0f, baseS = 1.0f, ringF = 0.86f;
-        waypointMarkerConeParameters(center, lenS, baseS, ringF);
-        generateOrientedWaypointMarker(center, wp.yawAngle(), color, lenS, ringF, baseS, waypointVertices, waypointColors);
+        if (curveWp) {
+            // Curve point: small plain sphere only (no yaw cone — yaw is auto).
+            const float curveR = 0.55f * kWaypointSphereRadiusWorld;
+            generateSphereVertices(center, curveR, color, waypointVertices, waypointColors);
+        } else {
+            float lenS = 1.0f, baseS = 1.0f, ringF = 0.86f;
+            waypointMarkerConeParameters(center, lenS, baseS, ringF);
+            generateOrientedWaypointMarker(center, wp.yawAngle(), color, lenS, ringF, baseS, waypointVertices, waypointColors);
+        }
     }
 
     if (waypointVertices.isEmpty())
@@ -1493,7 +1609,8 @@ void PathPlannerOpenGLWidget::drawGizmo()
         appendSphere(yzCenter, handleRadius * 0.8f, axisColor(TransformHandle::PlaneYZ, QVector3D(0.2f, 1.0f, 1.0f)), handleVertices, handleColors);
     }
 
-    // Yaw: reference tick at 0° (logical forward = world +Z), sweep arc, heading arrow, draggable cap at tip.
+    // Yaw: only for non-curve waypoints. Curve points have auto yaw — no draggable handle.
+    if (!selectedWaypointIsCurve())
     {
         const QVector3D refTickEnd = center + QVector3D(0.0f, 0.0f, 0.35f * axisLength);
         appendLine(center, refTickEnd, QVector3D(0.35f, 0.38f, 0.45f), lineVertices, lineColors);
@@ -1566,22 +1683,64 @@ void PathPlannerOpenGLWidget::drawPath()
     if (m_waypoints.size() < 2)
         return;
 
+    rebuildVisualizationCacheIfNeeded();
+
     QVector<float> pathVertices;
     QVector<float> pathColors;
 
-    for (size_t i = 0; i < m_waypoints.size() - 1; ++i)
+    // Helper to convert a logical-frame position to world frame (mirrors logicalToWorld).
+    auto logicalPosToWorld = [](const QVector3D &p) -> QVector3D {
+        return QVector3D(p.y(), p.z(), p.x());
+    };
+
+    if (m_visualizationPath.size() >= 2)
     {
-        const Waypoint &wp1 = m_waypoints[i];
-        const Waypoint &wp2 = m_waypoints[i + 1];
-        const QVector3D p1 = waypointToWorld(wp1);
-        const QVector3D p2 = waypointToWorld(wp2);
+        // Use the densified cache (handles both smooth curves and speed coloring).
+        const int n = m_visualizationPath.size();
+        for (int i = 0; i < n - 1; ++i)
+        {
+            const QVector3D p1 = logicalPosToWorld(m_visualizationPath[i]);
+            const QVector3D p2 = logicalPosToWorld(m_visualizationPath[i + 1]);
 
-        pathVertices << p1.x() << p1.y() << p1.z();
-        pathVertices << p2.x() << p2.y() << p2.z();
+            pathVertices << p1.x() << p1.y() << p1.z();
+            pathVertices << p2.x() << p2.y() << p2.z();
 
-        pathColors << 1.0f << 1.0f << 0.0f; // Yellow
-        pathColors << 1.0f << 1.0f << 0.0f;
+            // Determine segment color.
+            QVector3D color(1.0f, 1.0f, 0.0f); // default yellow
+            if (m_trajectoryVisualizationMode && i < m_visualizationSpeeds.size() - 1)
+            {
+                const float avgSpeed = (m_visualizationSpeeds[i] + m_visualizationSpeeds[i + 1]) * 0.5f;
+                const float s = avgSpeed / qMax(0.01f, m_visualizationCruiseMs);
+                if (s >= 0.8f)
+                    color = QVector3D(0.2f, 0.85f, 0.7f);   // teal — cruise
+                else if (s >= 0.4f)
+                    color = QVector3D(0.95f, 0.7f, 0.2f);   // amber — deceleration
+                else
+                    color = QVector3D(0.95f, 0.35f, 0.25f); // red — slow / hold
+            }
+
+            pathColors << color.x() << color.y() << color.z();
+            pathColors << color.x() << color.y() << color.z();
+        }
     }
+    else
+    {
+        // Fallback: straight segments between waypoints (degenerate or very short paths).
+        for (size_t i = 0; i < m_waypoints.size() - 1; ++i)
+        {
+            const QVector3D p1 = waypointToWorld(m_waypoints[i]);
+            const QVector3D p2 = waypointToWorld(m_waypoints[i + 1]);
+
+            pathVertices << p1.x() << p1.y() << p1.z();
+            pathVertices << p2.x() << p2.y() << p2.z();
+
+            pathColors << 1.0f << 1.0f << 0.0f; // Yellow
+            pathColors << 1.0f << 1.0f << 0.0f;
+        }
+    }
+
+    if (pathVertices.isEmpty())
+        return;
 
     m_vao.bind();
     m_vertexBuffer.bind();
@@ -1596,7 +1755,7 @@ void PathPlannerOpenGLWidget::drawPath()
     glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), nullptr);
     glEnableVertexAttribArray(1);
 
-    glLineWidth(3.0f);
+    glLineWidth(5.0f);
     glDrawArrays(GL_LINES, 0, pathVertices.size() / 3);
     glLineWidth(1.0f);
 
@@ -1605,12 +1764,70 @@ void PathPlannerOpenGLWidget::drawPath()
     m_vao.release();
 }
 
+void PathPlannerOpenGLWidget::setTrajectoryVisualization(bool on, float cruiseMs, float sampleHz)
+{
+    m_trajectoryVisualizationMode = on;
+    m_visualizationCruiseMs = cruiseMs;
+    m_visualizationSampleHz = sampleHz;
+    m_visualizationDirty = true;
+    update();
+}
+
+void PathPlannerOpenGLWidget::invalidateTrajectoryCache()
+{
+    m_visualizationDirty = true;
+    update();
+}
+
+void PathPlannerOpenGLWidget::rebuildVisualizationCacheIfNeeded()
+{
+    if (!m_visualizationDirty && !m_visualizationPath.isEmpty())
+        return;
+
+    m_visualizationPath.clear();
+    m_visualizationSpeeds.clear();
+
+    if (m_waypoints.size() < 2)
+    {
+        m_visualizationDirty = false;
+        return;
+    }
+
+    const float cruiseMs = qMax(0.5f, m_visualizationCruiseMs);
+    const float sampleHz = m_visualizationSampleHz > 0.0f ? m_visualizationSampleHz : 20.0f;
+
+    // Build positions (always — so curves render even without trajectory coloring).
+    m_visualizationPath = Trajectory::previewSampledPositionsLogical(m_waypoints, cruiseMs, sampleHz);
+
+    // Build speeds by constructing a full Trajectory and extracting velocity magnitudes.
+    const Trajectory traj = Trajectory::fromWaypoints(m_waypoints, cruiseMs, sampleHz);
+    const QVector<TrajectorySample> &trajSamples = traj.samples();
+    m_visualizationSpeeds.reserve(trajSamples.size());
+    for (const TrajectorySample &s : trajSamples)
+        m_visualizationSpeeds.append(s.velocityNed.length());
+
+    // Lengths must match; if they don't, log a warning and reset both.
+    if (m_visualizationPath.size() != m_visualizationSpeeds.size())
+    {
+        qWarning("rebuildVisualizationCacheIfNeeded: position count (%d) != speed count (%d); clearing cache.",
+                 static_cast<int>(m_visualizationPath.size()), static_cast<int>(m_visualizationSpeeds.size()));
+        m_visualizationPath.clear();
+        m_visualizationSpeeds.clear();
+    }
+
+    m_visualizationDirty = false;
+}
+
 void PathPlannerOpenGLWidget::mousePressEvent(QMouseEvent *event)
 {
     updateCamera();
     m_lastMousePos = event->pos();
     m_mousePressed = true;
     m_dragStartMousePos = event->pos();
+    // Hide the recording backbone while the user is interacting with the camera.
+    m_cameraInteracting = true;
+    if (m_backboneRevealTimer)
+        m_backboneRevealTimer->stop();
 
     if (event->button() == Qt::LeftButton)
     {
@@ -1690,6 +1907,10 @@ void PathPlannerOpenGLWidget::mousePressEvent(QMouseEvent *event)
             {
                 const std::vector<Waypoint> before = m_waypoints;
                 Waypoint wp(worldToLogical(insertWorld));
+                if (m_nextWaypointIsCurve) {
+                    wp.setCurve(true);
+                    wp.setCornerRadius(m_nextWaypointRadiusM > 0.0f ? m_nextWaypointRadiusM : 1.5f);
+                }
                 m_waypoints.insert(m_waypoints.begin() + segmentIndex + 1, wp);
                 normalizeMapperHomeAndRenumberSequences();
                 m_selectedWaypoint = m_waypoints[static_cast<size_t>(segmentIndex) + 1].sequence();
@@ -1939,12 +2160,16 @@ void PathPlannerOpenGLWidget::mouseReleaseEvent(QMouseEvent *event)
         emit waypointsEdited();
     }
     m_mousePressed = false;
+    m_cameraInteracting = false;
     update();
 }
 
 void PathPlannerOpenGLWidget::wheelEvent(QWheelEvent *event)
 {
     float delta = event->angleDelta().y() / 120.0f;
+    m_cameraInteracting = true;
+    if (m_backboneRevealTimer)
+        m_backboneRevealTimer->start();
 
     if (m_viewMode == TopDownMode)
     {
@@ -2188,6 +2413,7 @@ bool PathPlannerOpenGLWidget::updateWaypointYawAngle(int id, float yawDeg)
             if (qAbs(waypoint.yawAngle() - yawDeg) < 0.02f)
                 return false;
             waypoint.setYawAngle(yawDeg);
+            m_visualizationDirty = true;
             update();
             return true;
         }
@@ -2210,6 +2436,7 @@ bool PathPlannerOpenGLWidget::updateWaypointLogicalPosition(int id, const QVecto
             if ((QVector3D(waypoint.x(), waypoint.y(), waypoint.z()) - clamped).lengthSquared() < 1e-8f)
                 return false;
             waypoint.setPosition(clamped);
+            m_visualizationDirty = true;
             update();
             return true;
         }
@@ -2247,6 +2474,7 @@ void PathPlannerOpenGLWidget::setWaypoints(const std::vector<Waypoint> &waypoint
 {
     m_waypoints = waypoints;
     normalizeMapperHomeAndRenumberSequences();
+    m_visualizationDirty = true;
     if (m_selectedWaypoint >= 0) {
         bool found = false;
         for (const Waypoint &wp : m_waypoints) {
@@ -2278,6 +2506,10 @@ void PathPlannerOpenGLWidget::addWaypoint(const QVector3D &point)
     wp.setAcceptanceRadius(m_defaultAcceptanceRadius);
     wp.setHoldTime(m_defaultHoldTime);
     wp.setYawAngle(m_defaultYawAngle);
+    if (m_nextWaypointIsCurve) {
+        wp.setCurve(true);
+        wp.setCornerRadius(m_nextWaypointRadiusM > 0.0f ? m_nextWaypointRadiusM : 1.5f);
+    }
     m_waypoints.push_back(wp);
     m_selectedWaypoint = newSequence;
     m_selectedWaypointIds.clear();
@@ -2418,6 +2650,14 @@ void PathPlannerOpenGLWidget::setNavigationOnly(bool on)
     update();
 }
 
+void PathPlannerOpenGLWidget::setDecorationsHidden(bool hidden)
+{
+    if (m_decorationsHidden == hidden)
+        return;
+    m_decorationsHidden = hidden;
+    update();
+}
+
 void PathPlannerOpenGLWidget::setEditorTools(bool createEnabled, bool transformEnabled)
 {
     if (m_createToolEnabled == createEnabled && m_transformToolEnabled == transformEnabled)
@@ -2429,10 +2669,25 @@ void PathPlannerOpenGLWidget::setEditorTools(bool createEnabled, bool transformE
     update();
 }
 
+void PathPlannerOpenGLWidget::setNextWaypointAsCurve(bool enable, float defaultRadiusM)
+{
+    m_nextWaypointIsCurve = enable;
+    m_nextWaypointRadiusM = defaultRadiusM;
+}
+
+bool PathPlannerOpenGLWidget::selectedWaypointIsCurve() const
+{
+    for (const auto &wp : m_waypoints)
+        if (wp.sequence() == m_selectedWaypoint)
+            return wp.isCurve();
+    return false;
+}
+
 void PathPlannerOpenGLWidget::commitEdit(const std::vector<Waypoint> &before, const std::vector<Waypoint> &after)
 {
     if (m_applyingHistory || before == after)
         return;
+    m_visualizationDirty = true;
     clearRedoHistory();
     m_undoStack.append(EditCommand{before, after});
     updateHistorySignals();
@@ -2458,6 +2713,7 @@ bool PathPlannerOpenGLWidget::undo()
     m_applyingHistory = true;
     m_waypoints = cmd.before;
     m_applyingHistory = false;
+    m_visualizationDirty = true;
     normalizeMapperHomeAndRenumberSequences();
     if (m_selectedWaypoint >= 0) {
         bool found = false;
@@ -2485,6 +2741,7 @@ bool PathPlannerOpenGLWidget::redo()
     m_applyingHistory = true;
     m_waypoints = cmd.after;
     m_applyingHistory = false;
+    m_visualizationDirty = true;
     normalizeMapperHomeAndRenumberSequences();
     if (m_selectedWaypoint >= 0) {
         bool found = false;
@@ -2551,7 +2808,7 @@ void PathPlannerOpenGLWidget::resetCamera()
 
 // PathPlannerWidget Implementation
 PathPlannerWidget::PathPlannerWidget(QWidget *parent)
-    : QWidget(parent), m_mainLayout(nullptr), m_contentLayout(nullptr), m_topBarWidget(nullptr), m_controlsLayout(nullptr), m_topBarPreUploadToolbar(nullptr), m_topBarEditingCluster(nullptr), m_topBarMissionCluster(nullptr), m_topBarReturnToEditButton(nullptr), m_topBarLandButton(nullptr), m_topBarRtlButton(nullptr), m_topBarForceDisarmButton(nullptr), m_topBarFlightTermButton(nullptr), m_openglWidget(nullptr), m_waypointGroup(nullptr), m_viewGroup(nullptr), m_waypointTable(nullptr), m_waypointCountLabel(nullptr), m_waypointDefaultsButton(nullptr), m_defaultAcceptanceRadiusSpinBox(nullptr), m_defaultHoldSpinBox(nullptr), m_defaultYawSpinBox(nullptr), m_pathMenuButton(nullptr), m_uploadMissionButton(nullptr), m_missionPlayButton(nullptr), m_missionPauseContinueButton(nullptr), m_createModeButton(nullptr), m_transformModeButton(nullptr), m_playPathPreviewButton(nullptr), m_stopPathPreviewButton(nullptr), m_pathNameEdit(nullptr), m_missionStatusLabel(nullptr), m_resetCameraButton(nullptr), m_viewModeButton(nullptr), m_defaultAltitudeSpinBox(nullptr), m_undoEditButton(nullptr), m_redoEditButton(nullptr), m_pathPreviewAnimationTimer(nullptr), m_pathPreviewWaypointIndex(0), m_pathPreviewProgress(0.0f), m_isPlayingPathPreview(false), m_selectedWaypoint(-1), m_droneController(nullptr), m_hasUploadedSnapshot(false), m_waypointsDirtySinceUpload(false), m_editingLocked(false), m_updatingWaypointTable(false), m_reorderingWaypointRows(false)
+    : QWidget(parent), m_mainLayout(nullptr), m_contentLayout(nullptr), m_topBarWidget(nullptr), m_controlsLayout(nullptr), m_topBarPreUploadToolbar(nullptr), m_topBarEditingCluster(nullptr), m_topBarMissionCluster(nullptr), m_topBarReturnToEditButton(nullptr), m_topBarLandButton(nullptr), m_topBarRtlButton(nullptr), m_topBarForceDisarmButton(nullptr), m_topBarFlightTermButton(nullptr), m_openglWidget(nullptr), m_waypointGroup(nullptr), m_viewGroup(nullptr), m_waypointTable(nullptr), m_waypointCountLabel(nullptr), m_waypointDefaultsButton(nullptr), m_defaultAcceptanceRadiusSpinBox(nullptr), m_defaultHoldSpinBox(nullptr), m_defaultYawSpinBox(nullptr), m_pathMenuButton(nullptr), m_uploadMissionButton(nullptr), m_missionPlayButton(nullptr), m_missionPauseContinueButton(nullptr), m_createModeButton(nullptr), m_addCurvePointButton(nullptr), m_transformModeButton(nullptr), m_playPathPreviewButton(nullptr), m_stopPathPreviewButton(nullptr), m_previewDecorationsButton(nullptr), m_pathNameEdit(nullptr), m_missionStatusLabel(nullptr), m_resetCameraButton(nullptr), m_viewModeButton(nullptr), m_defaultAltitudeSpinBox(nullptr), m_undoEditButton(nullptr), m_redoEditButton(nullptr), m_pathPreviewAnimationTimer(nullptr), m_pathPreviewWaypointIndex(0), m_pathPreviewProgress(0.0f), m_isPlayingPathPreview(false), m_selectedWaypoint(-1), m_droneController(nullptr), m_hasUploadedSnapshot(false), m_waypointsDirtySinceUpload(false), m_editingLocked(false), m_updatingWaypointTable(false), m_reorderingWaypointRows(false)
 {
     setupUI();
 
@@ -2712,8 +2969,27 @@ void PathPlannerWidget::setupTopBar()
     m_redoEditButton = makeTopButton(QString::fromUtf8("\xE2\x86\xB7"));
     m_playPathPreviewButton = makeTopButton(QString::fromUtf8("\xE2\x96\xB6"));
     m_stopPathPreviewButton = makeTopButton(QString::fromUtf8("\xE2\x96\xA0"));
+    m_previewDecorationsButton = new QPushButton(QStringLiteral("Preview"), m_topBarWidget);
+    m_previewDecorationsButton->setFixedHeight(24);
+    m_previewDecorationsButton->setFlat(true);
+    m_previewDecorationsButton->setCheckable(true);
+    m_previewDecorationsButton->setStyleSheet(
+        "QPushButton { "
+        "  color: #c7d2de; "
+        "  background: transparent; "
+        "  border: none; "
+        "  border-radius: 0px; "
+        "  font-size: 12px; "
+        "  padding: 0px 6px; "
+        "} "
+        "QPushButton:hover { color: #f3f6fb; background-color: rgba(255,255,255,0.07); } "
+        "QPushButton:pressed { color: #ffffff; background-color: rgba(255,255,255,0.12); } "
+        "QPushButton:checked { color: #3fb1ff; background-color: rgba(63,177,255,0.10); } "
+        "QPushButton:disabled { color: #6b7280; background: transparent; }");
     m_transformModeButton = makeTopButton(QString::fromUtf8("\xE2\x86\x94"));
     m_createModeButton = makeTopButton(QStringLiteral("+"));
+    m_addCurvePointButton = makeTopButton(QString::fromUtf8("\xE2\xA4\xBF"));
+    m_addCurvePointButton->setCheckable(true);
     m_uploadMissionButton = makeTopButton(QString::fromUtf8("\xE2\x86\x91"));
     m_topBarReturnToEditButton =
         makeMissionToolbarButton(QString::fromUtf8("\xE2\x86\xA9"), QStringLiteral("#cbd5e1"), QStringLiteral("#f8fafc"));
@@ -2756,12 +3032,15 @@ void PathPlannerWidget::setupTopBar()
     m_createModeButton->setCheckable(true);
     m_transformModeButton->setCheckable(true);
     m_transformModeButton->setChecked(true);
+    // m_addCurvePointButton already set checkable above
 
     m_undoEditButton->setToolTip("Undo");
     m_redoEditButton->setToolTip("Redo");
     m_playPathPreviewButton->setToolTip("Preview path (local playback)");
     m_stopPathPreviewButton->setToolTip("Stop path preview");
+    m_previewDecorationsButton->setToolTip("Hide waypoint markers and labels, showing only the path line");
     m_createModeButton->setToolTip("Create waypoints (independent; works together with Transform)");
+    m_addCurvePointButton->setToolTip("Add curve points (auto-tangent arcs at each corner)");
     m_transformModeButton->setToolTip("Transform: show gizmo and drag handles on the selected waypoint");
     m_uploadMissionButton->setToolTip("Upload Mission");
     m_topBarReturnToEditButton->setToolTip("Return to Edit (unlock path; re-upload required after changes)");
@@ -2794,7 +3073,12 @@ void PathPlannerWidget::setupTopBar()
         "QToolButton::menu-indicator { image: none; width: 0px; }");
     QMenu *pathMenu = new QMenu(m_pathMenuButton);
     QAction *newPathAction = pathMenu->addAction("New");
+    QAction *clearPathAction = pathMenu->addAction("Clear Path");
     QAction *loadPathAction = pathMenu->addAction("Load");
+    QAction *loadFromRecordingAction = pathMenu->addAction("Load from Recording...");
+    loadFromRecordingAction->setToolTip(
+        "Reverse-engineer a smooth curve-point path from a FlightLogger recording. "
+        "Draws the raw flown trace as a low-opacity backbone behind the fitted curve.");
     QAction *savePathAction = pathMenu->addAction("Save");
     pathMenu->addSeparator();
     QAction *loadMapperMapAction = pathMenu->addAction("Load VOXL Map...");
@@ -2813,7 +3097,12 @@ void PathPlannerWidget::setupTopBar()
         m_pathNameEdit->setText("New Path");
         onClearPath();
     });
+    connect(clearPathAction, &QAction::triggered, this, [this]() {
+        m_pathNameEdit->setText("New Path");
+        onClearPath();
+    });
     connect(loadPathAction, &QAction::triggered, this, &PathPlannerWidget::onLoadPath);
+    connect(loadFromRecordingAction, &QAction::triggered, this, &PathPlannerWidget::onLoadPathFromRecording);
     connect(savePathAction, &QAction::triggered, this, &PathPlannerWidget::onSavePath);
     connect(loadMapperMapAction, &QAction::triggered, this, [this]() {
         if (!m_droneController || !m_droneController->isConnected()) {
@@ -2958,6 +3247,7 @@ void PathPlannerWidget::setupTopBar()
     makeThinSeparator(editLay);
     editLay->addWidget(m_transformModeButton);
     editLay->addWidget(m_createModeButton);
+    editLay->addWidget(m_addCurvePointButton);
     makeThinSeparator(editLay);
     editLay->addWidget(m_undoEditButton);
     editLay->addWidget(m_redoEditButton);
@@ -2970,6 +3260,8 @@ void PathPlannerWidget::setupTopBar()
     makeThinSeparator(preUploadLay);
     preUploadLay->addWidget(m_playPathPreviewButton);
     preUploadLay->addWidget(m_stopPathPreviewButton);
+    makeThinSeparator(preUploadLay);
+    preUploadLay->addWidget(m_previewDecorationsButton);
     makeThinSeparator(preUploadLay);
     preUploadLay->addWidget(m_uploadMissionButton);
 
@@ -3002,7 +3294,26 @@ void PathPlannerWidget::setupTopBar()
     m_missionStatusLabel->setAlignment(Qt::AlignVCenter | Qt::AlignRight);
     topLayout->addWidget(m_missionStatusLabel, 0, Qt::AlignVCenter);
 
-    connect(m_createModeButton, &QPushButton::toggled, this, &PathPlannerWidget::applyEditorToolsFromButtons);
+    // Tri-state mutual exclusion: createMode, curveMode, and transformMode.
+    // curveMode implies createMode (the OpenGL widget's effectiveCreate() uses m_createToolEnabled).
+    auto applyCreateMode = [this]() {
+        if (!m_openglWidget) return;
+        const bool curveActive = m_addCurvePointButton && m_addCurvePointButton->isChecked();
+        const bool waypointActive = m_createModeButton && m_createModeButton->isChecked();
+        const bool createOn = curveActive || waypointActive;
+        m_openglWidget->setEditorTools(createOn, m_transformModeButton && m_transformModeButton->isChecked());
+        m_openglWidget->setNextWaypointAsCurve(curveActive, m_nextCurveDefaultRadiusM);
+    };
+    connect(m_createModeButton, &QPushButton::toggled, this, [this, applyCreateMode](bool on) {
+        if (on && m_addCurvePointButton && m_addCurvePointButton->isChecked())
+            m_addCurvePointButton->setChecked(false);  // mutual exclusion
+        applyCreateMode();
+    });
+    connect(m_addCurvePointButton, &QPushButton::toggled, this, [this, applyCreateMode](bool on) {
+        if (on && m_createModeButton && m_createModeButton->isChecked())
+            m_createModeButton->setChecked(false);  // mutual exclusion
+        applyCreateMode();
+    });
     connect(m_transformModeButton, &QPushButton::toggled, this, &PathPlannerWidget::applyEditorToolsFromButtons);
     connect(m_topBarReturnToEditButton, &QPushButton::clicked, this, &PathPlannerWidget::onReturnToEdit);
     connect(m_missionPlayButton, &QPushButton::clicked, this, &PathPlannerWidget::onMissionPlayClicked);
@@ -3108,6 +3419,10 @@ void PathPlannerWidget::setupControls()
     connect(m_uploadMissionButton, &QPushButton::clicked, this, &PathPlannerWidget::onUploadMission);
     connect(m_playPathPreviewButton, &QPushButton::clicked, this, &PathPlannerWidget::onPlayPathPreview);
     connect(m_stopPathPreviewButton, &QPushButton::clicked, this, &PathPlannerWidget::onStopPathPreview);
+    connect(m_previewDecorationsButton, &QPushButton::toggled, this, [this](bool checked) {
+        if (m_openglWidget)
+            m_openglWidget->setDecorationsHidden(checked);
+    });
     connect(m_defaultAltitudeSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
             this, [this](double value)
             { m_openglWidget->setDefaultAltitude(static_cast<float>(value)); });
@@ -3176,8 +3491,8 @@ void PathPlannerWidget::setupWaypointTable()
 {
     m_waypointTable = new WaypointTableWidget;
     m_waypointTable->setItemDelegate(new WaypointNoFocusDelegate(m_waypointTable));
-    m_waypointTable->setColumnCount(5);
-    m_waypointTable->setHorizontalHeaderLabels({"X", "Y", "Z", "Yaw", "Hold"});
+    m_waypointTable->setColumnCount(7);
+    m_waypointTable->setHorizontalHeaderLabels({"X", "Y", "Z", "Yaw", "Hold", "Curve", "Radius"});
     m_waypointTable->setMinimumHeight(170);
     m_waypointTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     m_waypointTable->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -3238,6 +3553,8 @@ void PathPlannerWidget::setupWaypointTable()
     m_waypointTable->setColumnWidth(2, 52); // Z
     m_waypointTable->setColumnWidth(3, 52); // Yaw
     m_waypointTable->setColumnWidth(4, 52); // Hold
+    m_waypointTable->setColumnWidth(5, 56); // Curve
+    m_waypointTable->setColumnWidth(6, 60); // Radius
 
     // Insert waypoint table at the top of the waypoints section.
     QVBoxLayout *waypointLayout = qobject_cast<QVBoxLayout *>(m_waypointGroup->layout());
@@ -3295,7 +3612,11 @@ void PathPlannerWidget::onClearPath()
         stopPathPreviewAnimation();
 
     m_openglWidget->clearWaypoints();
+    m_openglWidget->clearRecordingBackbone();
     m_selectedWaypoint = -1;
+
+    m_lastMissionStatusText.clear();
+    updateMissionChrome();
 
     if (m_waypointTable)
         updateWaypointTable();
@@ -3446,6 +3767,100 @@ void PathPlannerWidget::onLoadPath()
         loadPathFromFile(fileName, true);
 }
 
+void PathPlannerWidget::onLoadPathFromRecording()
+{
+    // FlightLogger writes to <volume>/trajectories/. Fall back to the planner paths dir if unset.
+    QString startDir;
+    const QString appData = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+    if (!appData.isEmpty()) {
+        const QString trajDir = QDir(appData).filePath("trajectories");
+        if (QDir(trajDir).exists())
+            startDir = trajDir;
+    }
+    if (startDir.isEmpty())
+        startDir = m_plannerPathsDir.isEmpty() ? plannerPathsDirectory() : m_plannerPathsDir;
+
+    const QString fileName = QFileDialog::getOpenFileName(this,
+                                                          "Load Path from Recording",
+                                                          startDir,
+                                                          "Recording JSON (traj_*.json *.json)");
+    if (fileName.isEmpty())
+        return;
+    loadPathFromRecording(fileName);
+}
+
+bool PathPlannerWidget::loadPathFromRecording(const QString &fileName)
+{
+    QFile f(fileName);
+    if (!f.open(QIODevice::ReadOnly)) {
+        QMessageBox::warning(this, "Load Path from Recording",
+                             QString("Could not open file:\n%1").arg(fileName));
+        return false;
+    }
+    const QByteArray bytes = f.readAll();
+    f.close();
+
+    QJsonParseError perr{};
+    const QJsonDocument doc = QJsonDocument::fromJson(bytes, &perr);
+    if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
+        QMessageBox::warning(this, "Load Path from Recording",
+                             QString("Invalid JSON:\n%1").arg(perr.errorString()));
+        return false;
+    }
+
+    // FlightLogger produces a FlightPath-shaped JSON whose waypoints carry local_position
+    // (logical Z-up) and a name of the form "rec_<elapsed_ms>ms".
+    const FlightPath fp = FlightPath::fromJson(doc.object());
+    const QVector<Waypoint> &recorded = fp.waypoints();
+    if (recorded.size() < 2) {
+        QMessageBox::warning(this, "Load Path from Recording",
+                             "Recording has too few samples to fit a path.");
+        return false;
+    }
+
+    static const QRegularExpression msRegex(QStringLiteral("rec_(\\d+)ms"));
+    QVector<TimedSample> samples;
+    samples.reserve(recorded.size());
+    for (int i = 0; i < recorded.size(); ++i) {
+        const Waypoint &w = recorded[i];
+        TimedSample s;
+        s.positionLogical = w.position();
+        s.yawDeg = w.yawAngle();
+        const QRegularExpressionMatch m = msRegex.match(w.name());
+        s.t = m.hasMatch() ? (m.captured(1).toLongLong() / 1000.0)
+                           : (i * 0.5); // fallback: 500 ms cadence
+        samples.append(s);
+    }
+
+    const PathFitResult fit = fitPathFromSamples(samples);
+    if (fit.waypoints.empty()) {
+        QMessageBox::information(this, "Load Path from Recording",
+                                 "Recording is entirely stationary — nothing to fit.");
+        return false;
+    }
+
+    if (m_openglWidget) {
+        clearMapperVisualization();
+        m_openglWidget->setRecordingBackbone(fit.backboneLogical);
+        m_openglWidget->setWaypoints(fit.waypoints);
+    }
+
+    const QString loadedName = QFileInfo(fileName).baseName().replace('_', ' ');
+    if (m_pathNameEdit)
+        m_pathNameEdit->setText(loadedName);
+    if (m_waypointGroup)
+        m_waypointGroup->setTitle("Waypoints - " + loadedName);
+
+    updateWaypointTable();
+    emitWaypointsChanged();
+
+    m_lastMissionStatusText = QStringLiteral("Loaded %1 curve points from %2-sample recording")
+                                  .arg(fit.waypoints.size())
+                                  .arg(fit.rawSampleCount);
+    updateMissionChrome();
+    return true;
+}
+
 void PathPlannerWidget::clearMapperVisualization()
 {
     if (!m_openglWidget)
@@ -3542,6 +3957,24 @@ void PathPlannerWidget::onWaypointCellChanged(int row, int column)
             if (!item)
                 return;
 
+            if (column == 5) {
+                const bool curve = (item->checkState() == Qt::Checked);
+                updated.setCurve(curve);
+                m_openglWidget->updateWaypoint(id, updated);
+                // updateWaypoint emits waypointsEdited → table refresh needed
+                return;
+            }
+
+            if (column == 6) {
+                bool ok2 = false;
+                float r = static_cast<float>(item->text().toDouble(&ok2));
+                if (!ok2) return;
+                Waypoint updated2 = wp;
+                updated2.setCornerRadius(r);
+                m_openglWidget->updateWaypoint(wp.sequence(), updated2);
+                return;
+            }
+
             bool ok;
             float value = item->text().toFloat(&ok);
             if (!ok)
@@ -3559,6 +3992,7 @@ void PathPlannerWidget::onWaypointCellChanged(int row, int column)
                 updated.setZ(value);
                 break;
             case 3:
+                if (wp.isCurve()) return;  // yaw is auto for curve points
                 updated.setYawAngle(value);
                 break;
             case 4:
@@ -3613,7 +4047,10 @@ void PathPlannerWidget::applyEditorToolsFromButtons()
 {
     if (m_editingLocked || !m_openglWidget)
         return;
-    m_openglWidget->setEditorTools(m_createModeButton->isChecked(), m_transformModeButton->isChecked());
+    const bool curveActive = m_addCurvePointButton && m_addCurvePointButton->isChecked();
+    const bool createOn = (m_createModeButton && m_createModeButton->isChecked()) || curveActive;
+    m_openglWidget->setEditorTools(createOn, m_transformModeButton && m_transformModeButton->isChecked());
+    m_openglWidget->setNextWaypointAsCurve(curveActive, m_nextCurveDefaultRadiusM);
 }
 
 void PathPlannerWidget::onPlayPathPreview()
@@ -3691,12 +4128,32 @@ void PathPlannerWidget::updateWaypointTable()
             auto *zItem = new QTableWidgetItem(QString::number(wp.z(), 'f', 2));
             zItem->setFlags(cellFlags);
             m_waypointTable->setItem(i, 2, zItem);
-            auto *yawItem = new QTableWidgetItem(QString::number(wp.yawAngle(), 'f', 1));
-            yawItem->setFlags(cellFlags);
+            // Curve points: yaw is auto-derived from velocity heading; cell is read-only.
+            const bool yawIsAuto = wp.isCurve();
+            auto *yawItem = new QTableWidgetItem(
+                yawIsAuto ? QStringLiteral("auto")
+                          : QString::number(wp.yawAngle(), 'f', 1));
+            yawItem->setFlags(yawIsAuto
+                ? (Qt::ItemIsSelectable | Qt::ItemIsEnabled)
+                : cellFlags);
             m_waypointTable->setItem(i, 3, yawItem);
             auto *holdItem = new QTableWidgetItem(QString::number(wp.holdTime(), 'f', 1));
             holdItem->setFlags(cellFlags);
             m_waypointTable->setItem(i, 4, holdItem);
+
+            auto *curveItem = new QTableWidgetItem();
+            curveItem->setFlags(wp.isMapperHome()
+                ? (Qt::ItemIsSelectable | Qt::ItemIsEnabled)
+                : (Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable));
+            curveItem->setCheckState(wp.isCurve() ? Qt::Checked : Qt::Unchecked);
+            curveItem->setTextAlignment(Qt::AlignCenter);
+            m_waypointTable->setItem(i, 5, curveItem);
+
+            auto *radiusItem = new QTableWidgetItem(QString::number(wp.cornerRadius(), 'f', 2));
+            radiusItem->setFlags(wp.isMapperHome()
+                ? (Qt::ItemIsSelectable | Qt::ItemIsEnabled)
+                : (Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable));
+            m_waypointTable->setItem(i, 6, radiusItem);
         }
     }
 
@@ -3777,6 +4234,32 @@ void PathPlannerWidget::clearPath()
 }
 
 // New public API methods
+
+void PathPlannerWidget::setNextWaypointAsCurve(bool enable, float defaultRadiusM)
+{
+    m_nextWaypointIsCurve = enable;
+    m_nextCurveDefaultRadiusM = defaultRadiusM;
+    if (m_addCurvePointButton) {
+        const QSignalBlocker b(m_addCurvePointButton);
+        m_addCurvePointButton->setChecked(enable);
+    }
+    if (enable) {
+        // Mutual exclusion: clear regular-add mode
+        if (m_createModeButton && m_createModeButton->isChecked()) {
+            const QSignalBlocker bc(m_createModeButton);
+            m_createModeButton->setChecked(false);
+        }
+    }
+    if (m_openglWidget)
+        m_openglWidget->setNextWaypointAsCurve(enable, defaultRadiusM);
+}
+
+bool PathPlannerWidget::selectedWaypointIsCurve() const
+{
+    if (!m_openglWidget)
+        return false;
+    return m_openglWidget->selectedWaypointIsCurve();
+}
 
 void PathPlannerWidget::addWaypoint(const QVector3D &pos)
 {
@@ -3911,20 +4394,27 @@ void PathPlannerWidget::setEditingLocked(bool locked)
     if (lockChanged) {
         const QSignalBlocker bc(m_createModeButton);
         const QSignalBlocker bt(m_transformModeButton);
+        if (m_addCurvePointButton) m_addCurvePointButton->blockSignals(true);
         if (locked) {
             m_createModeButton->setChecked(false);
             m_transformModeButton->setChecked(false);
+            if (m_addCurvePointButton) m_addCurvePointButton->setChecked(false);
             m_openglWidget->setNavigationOnly(true);
+            m_openglWidget->setNextWaypointAsCurve(false, m_nextCurveDefaultRadiusM);
         } else {
             m_transformModeButton->setChecked(true);
             m_createModeButton->setChecked(false);
+            if (m_addCurvePointButton) m_addCurvePointButton->setChecked(false);
             m_openglWidget->setNavigationOnly(false);
             m_openglWidget->setEditorTools(false, true);
+            m_openglWidget->setNextWaypointAsCurve(false, m_nextCurveDefaultRadiusM);
         }
+        if (m_addCurvePointButton) m_addCurvePointButton->blockSignals(false);
     }
 
     m_createModeButton->setEnabled(!locked);
     m_transformModeButton->setEnabled(!locked);
+    if (m_addCurvePointButton) m_addCurvePointButton->setEnabled(!locked);
     m_undoEditButton->setEnabled(!locked && m_openglWidget->canUndo());
     m_redoEditButton->setEnabled(!locked && m_openglWidget->canRedo());
     m_waypointDefaultsButton->setEnabled(!locked);

--- a/qt-drone-ui/src/widgets/pathplannerwidget.h
+++ b/qt-drone-ui/src/widgets/pathplannerwidget.h
@@ -29,8 +29,12 @@
 #include <QSet>
 #include <QVector>
 #include <QEvent>
+#include <QComboBox>
+#include <QDesktopServices>
+#include <QUrl>
 #include <vector>
 #include "../models/waypoint.h"
+#include "../models/trajectory.h"
 
 class DroneController;
 class QFrame;
@@ -72,7 +76,13 @@ public:
     void setDefaultYawAngle(float yawDeg) { m_defaultYawAngle = yawDeg; }
     float defaultYawAngle() const { return m_defaultYawAngle; }
     void setNavigationOnly(bool on);
+    void setDecorationsHidden(bool hidden);
+    bool decorationsHidden() const { return m_decorationsHidden; }
     void setEditorTools(bool createEnabled, bool transformEnabled);
+    /// One-shot bias for the next addWaypoint(): make it a curve point with the given radius.
+    /// Sticks across multiple additions until cleared (called repeatedly from the UI on every toggle).
+    void setNextWaypointAsCurve(bool enable, float defaultRadiusM);
+    bool selectedWaypointIsCurve() const;
     bool createToolEnabled() const { return m_createToolEnabled; }
     bool transformToolEnabled() const { return m_transformToolEnabled; }
     bool undo();
@@ -84,6 +94,10 @@ public:
     void setDronePoseLogical(const QVector3D &positionLogical, float yawDeg);
     void setMapperRenderData(const QVector<QVector3D> &positionsLogical, const QVector<QColor> &colors);
     void setMapperMeshData(const QVector<QVector3D> &positionsLogical, const QVector<QColor> &colors, const QVector<quint32> &triangleIndices);
+    /// Set / clear the low-opacity dashed "first pass" overlay that shows the raw recording
+    /// behind a fitted curve path. Hidden during camera manipulation.
+    void setRecordingBackbone(const QVector<QVector3D> &positionsLogical);
+    void clearRecordingBackbone();
     const QVector<QVector3D> &mapperRenderPositionsLogical() const { return m_mapperRenderPositionsLogical; }
     const QVector<QColor> &mapperRenderColors() const { return m_mapperRenderColors; }
     const QVector<QVector3D> &mapperMeshPositionsLogical() const { return m_mapperMeshPositionsLogical; }
@@ -138,8 +152,13 @@ private:
     void drawAxes();
     void drawDroneAxes();
     void drawMapperRenderData();
+    void drawRecordingBackbone();
     void drawGizmo();
     void drawWaypointLabels(QPainter &painter);
+    // Trajectory visualization cache (rebuilt whenever waypoints or settings change).
+    void rebuildVisualizationCacheIfNeeded();
+    void setTrajectoryVisualization(bool on, float cruiseMs, float sampleHz);
+    void invalidateTrajectoryCache();
     void updateCamera();
     void updateProjection();
     QVector3D screenToWorld(const QPoint &screenPos, float depth = 0.0f);
@@ -203,8 +222,11 @@ private:
     // View mode
     ViewMode m_viewMode;
     bool m_navigationOnly = false;
+    bool m_decorationsHidden = false;
     bool m_createToolEnabled = false;
     bool m_transformToolEnabled = true;
+    bool  m_nextWaypointIsCurve = false;
+    float m_nextWaypointRadiusM = 0.0f;
     float m_orthoZoom;
     float m_defaultAltitude;
     float m_defaultAcceptanceRadius;
@@ -215,6 +237,10 @@ private:
     bool m_hasDronePose;
     QVector<QVector3D> m_mapperRenderPositionsLogical;
     QVector<QColor> m_mapperRenderColors;
+    // Dashed semi-transparent "first pass" overlay (raw flight-log positions, logical Z-up).
+    QVector<QVector3D> m_recordingBackbonePositionsLogical;
+    bool m_cameraInteracting = false;
+    QTimer *m_backboneRevealTimer = nullptr;
     QVector<QVector3D> m_mapperMeshPositionsLogical;
     QVector<QColor> m_mapperMeshColors;
     QVector<quint32> m_mapperMeshTriangleIndices;
@@ -246,7 +272,15 @@ private:
     QVector<EditCommand> m_undoStack;
     QVector<EditCommand> m_redoStack;
     bool m_applyingHistory;
-    
+
+    // Trajectory visualization cache
+    QVector<QVector3D> m_visualizationPath;    // logical-frame positions (Z-up)
+    QVector<float>     m_visualizationSpeeds;  // |v| per sample, same length as positions
+    bool m_visualizationDirty = true;
+    bool m_trajectoryVisualizationMode = false;
+    float m_visualizationCruiseMs = 2.5f;
+    float m_visualizationSampleHz = 20.0f;
+
     // Animation
     QTimer *m_animationTimer;
     float m_animationTime;
@@ -267,6 +301,9 @@ public:
     /// Pass an empty string to fall back to the built-in plannerPathsDirectory().
     void setPlannerPathsDirectory(const QString &dir);
 
+    void setNextWaypointAsCurve(bool enable, float defaultRadiusM);
+    bool selectedWaypointIsCurve() const;
+
     // Waypoint management
     void addWaypoint(const QVector3D &pos);
     void updateWaypoint(int id, const Waypoint &wp);
@@ -282,6 +319,9 @@ public:
     bool loadFromJson(const QString &path);
     /// Load waypoints + mapper metadata from disk; clears local mesh/plan preview; optional map reload uses clear-then-load on VOXL.
     bool loadPathFromFile(const QString &fileName, bool showSuccessDialog = true);
+    /// Parse a FlightLogger recording, fit a curve-point path, drop a low-opacity backbone overlay
+    /// of the raw trace into the scene. Returns false on read/parse failure.
+    bool loadPathFromRecording(const QString &fileName);
     void clearMapperVisualization();
 
 signals:
@@ -292,6 +332,7 @@ private slots:
     void onClearPath();
     void onSavePath();
     void onLoadPath();
+    void onLoadPathFromRecording();
     void onMapperBundleDownloadFinished(bool success, const QString &message);
     void onUploadMission();
     void onMissionPlayClicked();
@@ -376,11 +417,17 @@ private:
     QPushButton *m_missionPlayButton;
     QPushButton *m_missionPauseContinueButton;
     QPushButton *m_createModeButton;
+    QPushButton *m_addCurvePointButton = nullptr;
     QPushButton *m_transformModeButton;
     QPushButton *m_playPathPreviewButton;
     QPushButton *m_stopPathPreviewButton;
+    QPushButton *m_previewDecorationsButton;
     QLineEdit *m_pathNameEdit;
     QLabel *m_missionStatusLabel;
+
+    // Curve-mode state
+    bool  m_nextWaypointIsCurve = false;
+    float m_nextCurveDefaultRadiusM = 1.5f;
     
     // View controls
     QPushButton *m_resetCameraButton;


### PR DESCRIPTION
## Summary
- **Curve-point waypoints**: new CURVE type with per-vertex corner radius; yaw is auto-derived; tri-state toolbar toggle alongside create/transform.
- **Load path from recording**: parse a FlightLogger recording into a fitted curve-point path; overlays the raw trace as a low-opacity dashed backbone (hidden during camera manipulation).
- **Preview button**: toggles waypoint markers + labels off so only the path line is visible.
- **Clear Path** menu entry next to New.
- Also includes: speed-based path coloring (teal/amber/red), thicker path line, `corner_radius` field in waypoint JSON, and the full Trajectory model + upload/stage pipeline in DroneController.

## Test plan
- [ ] Add curve waypoints; verify auto yaw and arc rendering
- [ ] Load a FlightLogger recording; verify fitted path + dashed backbone
- [ ] Toggle Preview; markers/labels hide, path stays
- [ ] Clear Path resets the scene
- [ ] Save/load round-trips `corner_radius`

🤖 Generated with [Claude Code](https://claude.com/claude-code)